### PR TITLE
Allow none as value for samesite

### DIFF
--- a/src/SetCookie.php
+++ b/src/SetCookie.php
@@ -42,7 +42,7 @@ final class SetCookie
         string $sameSite = ''
     ) {
         $this->assertValidName($name);
-        $this->assertValidSameSite($sameSite);
+        $this->assertValidSameSite($sameSite, $secure);
         $this->name = $name;
         $this->value = $value;
         $this->expiresAt = $expiresAt;
@@ -106,10 +106,14 @@ final class SetCookie
         }
     }
 
-    private function assertValidSameSite(string $sameSite)
+    private function assertValidSameSite(string $sameSite, bool $secure)
     {
-        if (!in_array($sameSite, ['', 'lax', 'strict'])) {
-            throw new InvalidArgumentException('The same site attribute must be "lax", "strict" or ""');
+        if (!in_array($sameSite, ['', 'lax', 'strict', 'none'])) {
+            throw new InvalidArgumentException('The same site attribute must be "lax", "strict", "none" or ""');
+        }
+
+        if ($sameSite === 'none' && !$secure) {
+            throw new InvalidArgumentException('The same site attribute can only be "none" when secure is set to true');
         }
     }
 

--- a/tests/SetCookieTest.php
+++ b/tests/SetCookieTest.php
@@ -90,4 +90,14 @@ final class SetCookieTest extends \PHPUnit_Framework_TestCase
         $expected = sprintf('name=value; expires=%s; path=/path/; domain=domain.tld', gmdate(self::$HTTP_DATE_FORMAT, $expiresInFiveYear));
         $this->assertEquals($expected, $cookie->toHeaderValue());
     }
+
+    public function test_it_only_allows_samesite_none_with_secure()
+    {
+        $cookie = new SetCookie('name', 'value', time(), '/', '', true, true, 'none');
+        $this->assertEquals('none', $cookie->getSameSite());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("The same site attribute can only be \"none\" when secure is set to true");
+        $cookie = new SetCookie('name', 'value', time(), '/', '', false, true, 'none');
+    }
 }


### PR DESCRIPTION
Samesite=none is a valid value, however the validation does not currently allow this.

This blog post highlights when you'd want to use this value: https://web.dev/samesite-cookie-recipes/
`Cookies for cross-site usage must specify SameSite=None; Secure to enable inclusion in third party context.`