### PR TITLE
Using `psr/http-message:^2.0` and updating dependencies

### DIFF
--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -15,12 +15,13 @@ jobs:
                 dependencies:
                     - "locked"
                 php-version:
-                    - "7.0"
-                    - "7.1"
                     - "7.2"
                     - "7.3"
                     - "7.4"
                     - "8.0"
+                    - "8.1"
+                    - "8.2"
+                    - "8.3"
                 operating-system:
                     - "ubuntu-latest"
 

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     ],
     "require": {
         "php" : "^7.0 || ^8.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "scrutinizer/ocular": "~1.1",
-        "guzzlehttp/psr7": "^1.3",
+        "guzzlehttp/psr7": "^1.3 || ^2.0",
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,11 @@
     ],
     "require": {
         "php" : "^7.0 || ^8.0",
-        "psr/http-message": "^1.0 || ^2.0"
+        "psr/http-message": "^2.0"
     },
     "require-dev": {
         "scrutinizer/ocular": "~1.1",
-        "guzzlehttp/psr7": "^1.3 || ^2.0",
+        "guzzlehttp/psr7": "^2.0",
         "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "autoload": {

--- a/tests/SetCookieTest.php
+++ b/tests/SetCookieTest.php
@@ -39,10 +39,6 @@ final class SetCookieTest extends TestCase
 
     public function test_it_can_be_added_to_a_psr_response()
     {
-        if(!method_exists(Message::class, 'toString')) {
-            $this->markTestSkipped();
-        }
-
         $cookie = new SetCookie('name', 'value');
         $responseWithCookie = $cookie->addToResponse(new Response());
         $httpResponse = Message::toString($responseWithCookie);

--- a/tests/SetCookieTest.php
+++ b/tests/SetCookieTest.php
@@ -3,9 +3,9 @@
 namespace HansOtt\PSR7Cookies;
 
 use DateTimeImmutable;
+use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
-use function GuzzleHttp\Psr7\str;
 
 final class SetCookieTest extends TestCase
 {
@@ -39,9 +39,13 @@ final class SetCookieTest extends TestCase
 
     public function test_it_can_be_added_to_a_psr_response()
     {
+        if(!method_exists(Message::class, 'toString')) {
+            $this->markTestSkipped();
+        }
+
         $cookie = new SetCookie('name', 'value');
         $responseWithCookie = $cookie->addToResponse(new Response());
-        $httpResponse = str($responseWithCookie);
+        $httpResponse = Message::toString($responseWithCookie);
         $expected = 'HTTP/1.1 200 OK'."\r\n";
         $expected .= 'Set-Cookie: name=value'."\r\n\r\n";
         $this->assertEquals($expected, $httpResponse);


### PR DESCRIPTION
This pull request provides a dependency update to use `psr/http-message:^2.0`. It closes #16.

To use it, We also needed to update `guzzlehttp/psr7`. Addresses breaking changes included in `2.0`. Fortunately, only the test code was affected, so the old version of `guzzlehttp/psr7` can continue to be used.

Also, just to be sure, I changed the CI settings in my repository and confirmed that the tests would pass even with recent PHP versions, including the latest, which this repository does not yet support. It passes in all php versions from 7.0 to 8.3.

https://github.com/KentarouTakeda/hansott-psr7-cookies/actions/runs/7406316316

![test-results-in-my-repo](https://github.com/hansott/psr7-cookies/assets/4785040/3e88c69c-7635-48a1-9175-ef5cbe26a670)
