### PR TITLE
Trim whitespace from input values & cleanup

### DIFF
--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -2,7 +2,11 @@ name: "PHPUnit tests"
 
 on:
     pull_request:
+        branches:
+            - master
     push:
+        branches:
+            - master
 
 jobs:
     phpunit:
@@ -12,8 +16,6 @@ jobs:
 
         strategy:
             matrix:
-                dependencies:
-                    - "locked"
                 php-version:
                     - "7.2"
                     - "7.3"
@@ -27,37 +29,17 @@ jobs:
 
         steps:
             - name: "Checkout"
-              uses: "actions/checkout@v2"
+              uses: "actions/checkout@v4"
               with:
                   fetch-depth: 0
 
             - name: "Install PHP"
               uses: "shivammathur/setup-php@v2"
               with:
-                  php-version: "${{ matrix.php-version }}"
-                  ini-values: memory_limit=-1
-                  tools: composer:v2, cs2pr
+                  php-version: ${{ matrix.php-version }}
 
-            - name: "Cache dependencies"
-              uses: "actions/cache@v2"
-              with:
-                  path: |
-                      ~/.composer/cache
-                      vendor
-                  key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
-                  restore-keys: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}"
-
-            - name: "Install lowest dependencies"
-              if: ${{ matrix.dependencies == 'lowest' }}
-              run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest"
-
-            - name: "Install highest dependencies"
-              if: ${{ matrix.dependencies == 'highest' }}
-              run: "composer update --no-interaction --no-progress --no-suggest"
-
-            - name: "Install locked dependencies"
-              if: ${{ matrix.dependencies == 'locked' }}
-              run: "composer install --no-interaction --no-progress --no-suggest"
+            - name: "Update dependencies with composer"
+              uses: ramsey/composer-install@v2
 
             - name: "Tests"
               run: "vendor/bin/phpunit"

--- a/src/SetCookie.php
+++ b/src/SetCookie.php
@@ -5,6 +5,13 @@ namespace HansOtt\PSR7Cookies;
 
 use DateTimeInterface;
 use Psr\Http\Message\ResponseInterface;
+use function gmdate;
+use function in_array;
+use function preg_match;
+use function sprintf;
+use function time;
+use function trim;
+use function urlencode;
 
 final class SetCookie
 {

--- a/src/SetCookie.php
+++ b/src/SetCookie.php
@@ -41,16 +41,17 @@ final class SetCookie
         bool $httpOnly = false,
         string $sameSite = ''
     ) {
-        $this->assertValidName($name);
-        $this->assertValidSameSite($sameSite, $secure);
-        $this->name = $name;
-        $this->value = $value;
+        $this->name = trim($name);
+        $this->value = trim($value);
         $this->expiresAt = $expiresAt;
-        $this->path = $path;
-        $this->domain = $domain;
+        $this->path = trim($path);
+        $this->domain = trim($domain);
         $this->secure = $secure;
         $this->httpOnly = $httpOnly;
-        $this->sameSite = $sameSite;
+        $this->sameSite = trim($sameSite);
+
+        $this->assertValidName($this->name);
+        $this->assertValidSameSite($this->sameSite, $this->secure);
     }
 
     public static function thatDeletesCookie(
@@ -168,11 +169,11 @@ final class SetCookie
             );
         }
 
-        if (empty($this->path) === false) {
+        if ($this->path !== '') {
             $headerValue .= sprintf('; path=%s', $this->path);
         }
 
-        if (empty($this->domain) === false) {
+        if ($this->domain !== '') {
             $headerValue .= sprintf('; domain=%s', $this->domain);
         }
 

--- a/src/SetCookie.php
+++ b/src/SetCookie.php
@@ -62,7 +62,7 @@ final class SetCookie
         bool $httpOnly = false,
         string $sameSite = ''
     ) : SetCookie {
-        return new static($name, 'deleted', 1, $path, $domain, $secure, $httpOnly, $sameSite);
+        return new self($name, 'deleted', 1, $path, $domain, $secure, $httpOnly, $sameSite);
     }
 
     public static function thatExpires(
@@ -77,7 +77,7 @@ final class SetCookie
     ) : SetCookie {
         $expiresAt = (int) $expiresAt->format('U');
 
-        return new static($name, $value, $expiresAt, $path, $domain, $secure, $httpOnly, $sameSite);
+        return new self($name, $value, $expiresAt, $path, $domain, $secure, $httpOnly, $sameSite);
     }
 
     public static function thatStaysForever(
@@ -91,7 +91,7 @@ final class SetCookie
     ) : SetCookie {
         $expiresInFiveYear = time() + 5 * 365 * 3600 * 24;
 
-        return new static($name, $value, $expiresInFiveYear, $path, $domain, $secure, $httpOnly, $sameSite);
+        return new self($name, $value, $expiresInFiveYear, $path, $domain, $secure, $httpOnly, $sameSite);
     }
 
     private function assertValidName(string $name)

--- a/tests/SetCookieTest.php
+++ b/tests/SetCookieTest.php
@@ -61,6 +61,12 @@ final class SetCookieTest extends TestCase
         $cookie = new SetCookie('name', 'value', 0, '/path/');
         $this->assertEquals('name=value; path=/path/', $cookie->toHeaderValue());
 
+        $cookie = new SetCookie(' name  ', '   value  ', 0, '   /path/ '); // whitespace
+        $this->assertEquals('name=value; path=/path/', $cookie->toHeaderValue());
+
+        $cookie = new SetCookie('name', 'value', 0, '0'); // falsey path value
+        $this->assertEquals('name=value; path=0', $cookie->toHeaderValue());
+
         $cookie = new SetCookie('name', 'value', 0, '/path/', 'domain.tld');
         $this->assertEquals('name=value; path=/path/; domain=domain.tld', $cookie->toHeaderValue());
 

--- a/tests/SetCookieTest.php
+++ b/tests/SetCookieTest.php
@@ -32,12 +32,12 @@ final class SetCookieTest extends TestCase
         $httpOnly = true;
         $sameSite = 'lax';
         $setCookie = new SetCookie('name', 'value', $expiresAt, $path, $domain, $secure, $httpOnly, $sameSite);
-        $this->assertSame($expiresAt, $setCookie->expiresAt());
-        $this->assertSame($path, $setCookie->getPath());
-        $this->assertSame($domain, $setCookie->getDomain());
-        $this->assertSame($secure, $setCookie->isSecure());
-        $this->assertSame($httpOnly, $setCookie->isHttpOnly());
-        $this->assertSame($sameSite, $setCookie->getSameSite());
+        self::assertSame($expiresAt, $setCookie->expiresAt());
+        self::assertSame($path, $setCookie->getPath());
+        self::assertSame($domain, $setCookie->getDomain());
+        self::assertSame($secure, $setCookie->isSecure());
+        self::assertSame($httpOnly, $setCookie->isHttpOnly());
+        self::assertSame($sameSite, $setCookie->getSameSite());
     }
 
     public function test_it_can_be_added_to_a_psr_response()
@@ -47,64 +47,64 @@ final class SetCookieTest extends TestCase
         $httpResponse = Message::toString($responseWithCookie);
         $expected = 'HTTP/1.1 200 OK'."\r\n";
         $expected .= 'Set-Cookie: name=value'."\r\n\r\n";
-        $this->assertSame($expected, $httpResponse);
+        self::assertSame($expected, $httpResponse);
     }
 
     public function test_it_converts_to_header_value()
     {
         $cookie = new SetCookie('name', 'value');
-        $this->assertSame('name=value', $cookie->toHeaderValue());
+        self::assertSame('name=value', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('NaMe', 'value', 0);
-        $this->assertSame('NaMe=value', $cookie->toHeaderValue());
+        self::assertSame('NaMe=value', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value with space');
-        $this->assertSame('name=value+with+space', $cookie->toHeaderValue());
+        self::assertSame('name=value+with+space', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 0, '/path/');
-        $this->assertSame('name=value; path=/path/', $cookie->toHeaderValue());
+        self::assertSame('name=value; path=/path/', $cookie->toHeaderValue());
 
         $cookie = new SetCookie(' name  ', '   value  ', 0, '   /path/ '); // whitespace
-        $this->assertSame('name=value; path=/path/', $cookie->toHeaderValue());
+        self::assertSame('name=value; path=/path/', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 0, '0'); // falsey path value
-        $this->assertSame('name=value; path=0', $cookie->toHeaderValue());
+        self::assertSame('name=value; path=0', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 0, '/path/', 'domain.tld');
-        $this->assertSame('name=value; path=/path/; domain=domain.tld', $cookie->toHeaderValue());
+        self::assertSame('name=value; path=/path/; domain=domain.tld', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 0, '/path/', 'domain.tld', true);
-        $this->assertSame('name=value; path=/path/; domain=domain.tld; secure', $cookie->toHeaderValue());
+        self::assertSame('name=value; path=/path/; domain=domain.tld; secure', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 0, '/path/', 'domain.tld', true, true);
-        $this->assertSame('name=value; path=/path/; domain=domain.tld; secure; httponly', $cookie->toHeaderValue());
+        self::assertSame('name=value; path=/path/; domain=domain.tld; secure; httponly', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 1466459967, '', '', true, true);
-        $this->assertSame('name=value; expires=Mon, 20 Jun 2016 21:59:27 GMT; secure; httponly', $cookie->toHeaderValue());
+        self::assertSame('name=value; expires=Mon, 20 Jun 2016 21:59:27 GMT; secure; httponly', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 0, '/path/', 'domain.tld', true, true, 'strict');
-        $this->assertSame('name=value; path=/path/; domain=domain.tld; secure; httponly; samesite=strict', $cookie->toHeaderValue());
+        self::assertSame('name=value; path=/path/; domain=domain.tld; secure; httponly; samesite=strict', $cookie->toHeaderValue());
 
         $cookie = SetCookie::thatDeletesCookie('name');
         $expected = sprintf('name=deleted; expires=%s', gmdate(self::$HTTP_DATE_FORMAT, 1));
-        $this->assertSame($expected, $cookie->toHeaderValue());
+        self::assertSame($expected, $cookie->toHeaderValue());
 
         $now = new DateTimeImmutable();
         $cookie = SetCookie::thatExpires('name', 'value', $now);
         $timestamp = (int) $now->format('U');
         $expected = sprintf('name=value; expires=%s', gmdate(self::$HTTP_DATE_FORMAT, $timestamp));
-        $this->assertSame($expected, $cookie->toHeaderValue());
+        self::assertSame($expected, $cookie->toHeaderValue());
 
         $cookie = SetCookie::thatStaysForever('name', 'value', '/path/', 'domain.tld');
         $expiresInFiveYear = time() + 5 * 365 * 3600 * 24;
         $expected = sprintf('name=value; expires=%s; path=/path/; domain=domain.tld', gmdate(self::$HTTP_DATE_FORMAT, $expiresInFiveYear));
-        $this->assertSame($expected, $cookie->toHeaderValue());
+        self::assertSame($expected, $cookie->toHeaderValue());
     }
 
     public function test_it_only_allows_samesite_none_with_secure()
     {
         $cookie = new SetCookie('name', 'value', time(), '/', '', true, true, 'none');
-        $this->assertSame('none', $cookie->getSameSite());
+        self::assertSame('none', $cookie->getSameSite());
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("The same site attribute can only be \"none\" when secure is set to true");

--- a/tests/SetCookieTest.php
+++ b/tests/SetCookieTest.php
@@ -6,6 +6,9 @@ use DateTimeImmutable;
 use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use function gmdate;
+use function sprintf;
+use function time;
 
 final class SetCookieTest extends TestCase
 {

--- a/tests/SetCookieTest.php
+++ b/tests/SetCookieTest.php
@@ -47,64 +47,64 @@ final class SetCookieTest extends TestCase
         $httpResponse = Message::toString($responseWithCookie);
         $expected = 'HTTP/1.1 200 OK'."\r\n";
         $expected .= 'Set-Cookie: name=value'."\r\n\r\n";
-        $this->assertEquals($expected, $httpResponse);
+        $this->assertSame($expected, $httpResponse);
     }
 
     public function test_it_converts_to_header_value()
     {
         $cookie = new SetCookie('name', 'value');
-        $this->assertEquals('name=value', $cookie->toHeaderValue());
+        $this->assertSame('name=value', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('NaMe', 'value', 0);
-        $this->assertEquals('NaMe=value', $cookie->toHeaderValue());
+        $this->assertSame('NaMe=value', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value with space');
-        $this->assertEquals('name=value+with+space', $cookie->toHeaderValue());
+        $this->assertSame('name=value+with+space', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 0, '/path/');
-        $this->assertEquals('name=value; path=/path/', $cookie->toHeaderValue());
+        $this->assertSame('name=value; path=/path/', $cookie->toHeaderValue());
 
         $cookie = new SetCookie(' name  ', '   value  ', 0, '   /path/ '); // whitespace
-        $this->assertEquals('name=value; path=/path/', $cookie->toHeaderValue());
+        $this->assertSame('name=value; path=/path/', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 0, '0'); // falsey path value
-        $this->assertEquals('name=value; path=0', $cookie->toHeaderValue());
+        $this->assertSame('name=value; path=0', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 0, '/path/', 'domain.tld');
-        $this->assertEquals('name=value; path=/path/; domain=domain.tld', $cookie->toHeaderValue());
+        $this->assertSame('name=value; path=/path/; domain=domain.tld', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 0, '/path/', 'domain.tld', true);
-        $this->assertEquals('name=value; path=/path/; domain=domain.tld; secure', $cookie->toHeaderValue());
+        $this->assertSame('name=value; path=/path/; domain=domain.tld; secure', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 0, '/path/', 'domain.tld', true, true);
-        $this->assertEquals('name=value; path=/path/; domain=domain.tld; secure; httponly', $cookie->toHeaderValue());
+        $this->assertSame('name=value; path=/path/; domain=domain.tld; secure; httponly', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 1466459967, '', '', true, true);
-        $this->assertEquals('name=value; expires=Mon, 20 Jun 2016 21:59:27 GMT; secure; httponly', $cookie->toHeaderValue());
+        $this->assertSame('name=value; expires=Mon, 20 Jun 2016 21:59:27 GMT; secure; httponly', $cookie->toHeaderValue());
 
         $cookie = new SetCookie('name', 'value', 0, '/path/', 'domain.tld', true, true, 'strict');
-        $this->assertEquals('name=value; path=/path/; domain=domain.tld; secure; httponly; samesite=strict', $cookie->toHeaderValue());
+        $this->assertSame('name=value; path=/path/; domain=domain.tld; secure; httponly; samesite=strict', $cookie->toHeaderValue());
 
         $cookie = SetCookie::thatDeletesCookie('name');
         $expected = sprintf('name=deleted; expires=%s', gmdate(self::$HTTP_DATE_FORMAT, 1));
-        $this->assertEquals($expected, $cookie->toHeaderValue());
+        $this->assertSame($expected, $cookie->toHeaderValue());
 
         $now = new DateTimeImmutable();
         $cookie = SetCookie::thatExpires('name', 'value', $now);
         $timestamp = (int) $now->format('U');
         $expected = sprintf('name=value; expires=%s', gmdate(self::$HTTP_DATE_FORMAT, $timestamp));
-        $this->assertEquals($expected, $cookie->toHeaderValue());
+        $this->assertSame($expected, $cookie->toHeaderValue());
 
         $cookie = SetCookie::thatStaysForever('name', 'value', '/path/', 'domain.tld');
         $expiresInFiveYear = time() + 5 * 365 * 3600 * 24;
         $expected = sprintf('name=value; expires=%s; path=/path/; domain=domain.tld', gmdate(self::$HTTP_DATE_FORMAT, $expiresInFiveYear));
-        $this->assertEquals($expected, $cookie->toHeaderValue());
+        $this->assertSame($expected, $cookie->toHeaderValue());
     }
 
     public function test_it_only_allows_samesite_none_with_secure()
     {
         $cookie = new SetCookie('name', 'value', time(), '/', '', true, true, 'none');
-        $this->assertEquals('none', $cookie->getSameSite());
+        $this->assertSame('none', $cookie->getSameSite());
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("The same site attribute can only be \"none\" when secure is set to true");


### PR DESCRIPTION
Hey, this PR trims the whitespace from input values and explicitly checks against an empty string `''` so that falsey values may pass - the [`empty()`](https://www.php.net/manual/en/function.empty) check here would fail on a string value of `0`:

https://github.com/hansott/psr7-cookies/blob/fdd4790274996a3d5a723fa32d1c82e2b319e8fc/src/SetCookie.php#L171

Further I did some cleanup and updated the GH Actions workflow run (removed the low/high dependency stuff - the only call was to "locked" without a lock file).